### PR TITLE
Minor fix on the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ZfrStripe is a modern PHP library based on Guzzle for [Stripe payment system](ht
 Installation of ZfrStripe is only officially supported using Composer:
 
 ```sh
-php composer.phar require zfr/zfr-stripe:2.*
+php composer.phar require 'zfr/zfr-stripe:2.*'
 ```
 
 ## Tutorial


### PR DESCRIPTION
Put module name between single quotes. Using the composer require command without quotes results in an invalid command.